### PR TITLE
Fix list styles collision

### DIFF
--- a/docs/development/deployment-overview.md
+++ b/docs/development/deployment-overview.md
@@ -3,9 +3,9 @@ title: Dev and Deployment Overview
 sidebar_position: 1
 ---
 
-# Resources for Developing and Deploying Marlowe Contracts
+## Resources for Developing and Deploying Marlowe Contracts
 
-## How do I run my Marlowe contract on the Cardano blockchain?
+### How do I run my Marlowe contract on the Cardano blockchain?
 
 1. Design your contract using [Marlowe Playground](https://play.marlowe-finance.io/#/).
 

--- a/docs/examples/cli-cookbook.md
+++ b/docs/examples/cli-cookbook.md
@@ -2,8 +2,6 @@
 title: Marlowe CLI cookbook examples
 ---
 
-# Marlowe CLI cookbook examples
-
 | Example | Description | URL |
 | --- | --- | --- |
 | Using Djed in Marlowe Contracts | Description goes here | https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe-cli/cookbook/payment-using-djed.ipynb | 

--- a/docs/getting-started-with-the-marlowe-playground.md
+++ b/docs/getting-started-with-the-marlowe-playground.md
@@ -3,8 +3,6 @@ title: Getting started with the Marlowe Playground
 sidebar_position: 1
 ---
 
-# Getting started with the Marlowe Playground
-
 The [Marlowe Playground](https://play.marlowe-finance.io) is the medium for end-to-end financial smart contract development. It provides a means for developers to not only write smart contract code, but to also perform preliminary iterative design using simulations, ability to formally verify, and ability to test smart contracts. These capabilities, paired with a purpose-built DSL for finance ensures that the contracts are easy and straightforward to build, secure, verifiable, and rigorously tested. 
 
 The playground is available to use so that you can develop, simulate, and test the process of writing smart contracts in a sandbox environment. Its purpose is to encourage all types of developers, even if you don’t have prior Haskell or Javascript experience, to build financial products. Marlowe is in the process of deployment on Cardano, however, the Marlowe Playground already provides an environment, where users can try out its functionality in advance of the full deployment. A set of [tutorials](tutorials/tutorials-overview.md) is available that outlines example contracts and overview information on Marlowe and how contracts should be modelled. 

--- a/docs/marlowe-language-guide.md
+++ b/docs/marlowe-language-guide.md
@@ -1,9 +1,6 @@
 ---
 title: Marlowe language guide
-metaTitle: Marlowe language guide
 ---
-
-# Marlowe language guide
 
 Marlowe is designed to create the building blocks of financial contracts: payments to and deposits from participants, choices by participants, and real world information. 
 

--- a/docs/tutorials/actus-marlowe.md
+++ b/docs/tutorials/actus-marlowe.md
@@ -3,8 +3,6 @@ title: ACTUS and Marlowe
 sidebar_position: 1
 ---
 
-# ACTUS and Marlowe
-
 This tutorial gives an introduction to the general idea of the ACTUS
 standards for the algorithmic representation of financial contracts,
 plus examples implemented in Marlowe.

--- a/docs/tutorials/embedded-marlowe.md
+++ b/docs/tutorials/embedded-marlowe.md
@@ -3,8 +3,6 @@ title: Marlowe embedded in Haskell
 sidebar_position: 1
 ---
 
-# Marlowe embedded in Haskell
-
 In this tutorial we go back to the escrow example, and show how we can
 use the *embedding* of Marlowe in Haskell to make more readable, modular
 and reusable descriptions of Marlowe contracts.

--- a/docs/tutorials/escrow-ex.md
+++ b/docs/tutorials/escrow-ex.md
@@ -3,8 +3,6 @@ title: A first example
 sidebar_position: 1
 ---
 
-# A first example
-
 This tutorial introduces a simple financial contract in pseudocode,
 before explaining how it is modified to work in Marlowe, giving the
 first example of a Marlowe contract.

--- a/docs/writing-marlowe-with-blockly.md
+++ b/docs/writing-marlowe-with-blockly.md
@@ -1,6 +1,5 @@
 ---
 title: Writing Marlowe with Blockly
-metaTitle: Writing Marlowe with Blockly
 ---
 
 You can write Marlowe code directly as Marlowe text, or alternatively use the Blockly visual interface to piece together the parts of the contract. This is a very useful tool for those users who may not have experience in programming editors, and want to build the contracts visually.

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -36,6 +36,14 @@ body {
   font-family: Barlow, sans-serif;
 }
 
+main ul {
+  list-style: disc;
+}
+
+main ol {
+  list-style: decimal;
+}
+
 .new-tab a::after {
   content: url("/static/img/chevron-external-light.svg");
   width: 24px;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -136,8 +136,6 @@ module.exports = {
     fontWeight: true,
     height: true,
     lineHeight: true,
-    listStylePosition: false,
-    listStyleType: false,
     maxHeight: true,
     maxWidth: true,
     minHeight: true,


### PR DESCRIPTION
Current fix is cude and enough to get the ul/ol showing properly again. Don't want to keep introducing more custom globals to patch around when the problem is more fundamental.

https://input-output.atlassian.net/browse/SCP-5118 should eventually tackle this.

Also `metaTitle` is not valid front matter - see https://docusaurus.io/docs/create-doc#doc-front-matter for docs on this