### PR TITLE
moved Marlowe language guide from Getting Started section to Develope…

### DIFF
--- a/docs/development/marlowe-language-guide.md
+++ b/docs/development/marlowe-language-guide.md
@@ -20,9 +20,9 @@ In modelling basic parts of Marlowe a combination of Haskell `data` types are us
 
 In addition to writing contracts in the textual version of Marlowe, you can also use one of the following visual programming environments:
 
-1. [Using Blockly](writing-marlowe-with-blockly.md)
-2. [Using JavaScript](using-the-javascript-editor.md)
-3. [Using Haskell](using-the-haskell-editor.md)
+1. [Using Blockly](getting-started/writing-marlowe-with-blockly.md)
+2. [Using JavaScript](getting-started/using-the-javascript-editor.md)
+3. [Using Haskell](getting-started/using-the-haskell-editor.md)
 
 ## About a Marlowe contract
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -10,7 +10,6 @@ const sidebars = {
       items: [
         'introduction',
         'getting-started/getting-started-with-the-marlowe-playground',
-        'getting-started/marlowe-language-guide',
         'getting-started/writing-marlowe-with-blockly',
         'getting-started/using-the-haskell-editor',
         'getting-started/using-the-javascript-editor',
@@ -56,6 +55,7 @@ const sidebars = {
       items: [
         'development/deployment-overview',
         'development/dsl',
+        'development/marlowe-language-guide',
         'development/platform',
         'development/playground',
         'development/runtime',


### PR DESCRIPTION
…r Tools section

To keep the Getting Started section generally appealing to the low-code reader, I moved the Marlowe Language Guide page to the Developer Tools section. 