### PR TITLE
PLT-4272-Updated Platform page

### DIFF
--- a/docs/development/marlowe-runtime-cli.md
+++ b/docs/development/marlowe-runtime-cli.md
@@ -14,7 +14,7 @@ title: Marlowe Runtime CLI
 > 
 >  The document `marlowe-runtime/doc/marlowe.md` is out of date. It's likely that the `add`, `rm`, and `submit` commands will be removed, perhaps before the end of this PI. 
 
-Please see the links below to access more detailed documentation of the Runtime commands. 
+Please see the links below to access more detailed documentation of the Runtime CLI commands. 
 
 ### Building transactions
 

--- a/docs/development/platform.md
+++ b/docs/development/platform.md
@@ -74,3 +74,9 @@ and in this eprints survey paper.
 
 *   [Scripting smart contracts for distributed ledger technology](https://iohk.io/en/research/library/papers/scripting-smart-contracts-for-distributed-ledger-technology/)
     Here we give an overview of the scripting languages used in existing cryptocurrencies.
+
+## Further important information
+
+### [Best Practices for Marlowe on Cardano](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/best-practices.md)
+
+### [Marlowe Security Guide](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/security.md)


### PR DESCRIPTION
Added links to two documents at the bottom of the Platform page: 
1. Best Practices for Marlowe on Cardano, and 
3. Marlowe Security Guide