### PR TITLE
PLT-4140 - Add lunr.js based local search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -45,7 +45,17 @@ const config = {
     ],
   ],
 
-  themes: ['@docusaurus/theme-mermaid'],
+  themes: [
+    '@docusaurus/theme-mermaid',
+    [
+      require.resolve("@easyops-cn/docusaurus-search-local"),
+      /** @type {import("@easyops-cn/docusaurus-search-local").PluginOptions} */
+      ({
+
+        hashed: true,
+      }),
+    ],
+  ],
   markdown: {
     mermaid: true,
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@docusaurus/theme-classic": "^2.4.0",
     "@docusaurus/theme-common": "^2.4.0",
     "@docusaurus/theme-mermaid": "^2.4.0",
+    "@easyops-cn/docusaurus-search-local": "^0.35.0",
     "@mdx-js/react": "^1.6.22",
     "autoprefixer": "^10.4.13",
     "clsx": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1867,7 +1867,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-docs@npm:2.4.0, @docusaurus/plugin-content-docs@npm:^2.0.0":
+"@docusaurus/plugin-content-docs@npm:2.4.0, @docusaurus/plugin-content-docs@npm:^2.0.0, @docusaurus/plugin-content-docs@npm:^2.0.0-rc.1":
   version: 2.4.0
   resolution: "@docusaurus/plugin-content-docs@npm:2.4.0"
   dependencies:
@@ -2140,7 +2140,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-translations@npm:2.4.0":
+"@docusaurus/theme-translations@npm:2.4.0, @docusaurus/theme-translations@npm:^2.0.0-rc.1":
   version: 2.4.0
   resolution: "@docusaurus/theme-translations@npm:2.4.0"
   dependencies:
@@ -2169,7 +2169,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-common@npm:2.4.0":
+"@docusaurus/utils-common@npm:2.4.0, @docusaurus/utils-common@npm:^2.0.0-rc.1":
   version: 2.4.0
   resolution: "@docusaurus/utils-common@npm:2.4.0"
   dependencies:
@@ -2183,7 +2183,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-validation@npm:2.4.0, @docusaurus/utils-validation@npm:^2.0.0":
+"@docusaurus/utils-validation@npm:2.4.0, @docusaurus/utils-validation@npm:^2.0.0, @docusaurus/utils-validation@npm:^2.0.0-rc.1":
   version: 2.4.0
   resolution: "@docusaurus/utils-validation@npm:2.4.0"
   dependencies:
@@ -2196,7 +2196,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/utils@npm:2.4.0, @docusaurus/utils@npm:^2.0.0":
+"@docusaurus/utils@npm:2.4.0, @docusaurus/utils@npm:^2.0.0, @docusaurus/utils@npm:^2.0.0-rc.1":
   version: 2.4.0
   resolution: "@docusaurus/utils@npm:2.4.0"
   dependencies:
@@ -2222,6 +2222,44 @@ __metadata:
     "@docusaurus/types":
       optional: true
   checksum: 7ba6634b6ff71bb7cc64b0eb3c6d2892a21873bce8559bcd460693a80ca0229828c04da751277cdb17c6f18e80e061322bbcd84e9b743adc96c594b43e8a2165
+  languageName: node
+  linkType: hard
+
+"@easyops-cn/autocomplete.js@npm:^0.38.1":
+  version: 0.38.1
+  resolution: "@easyops-cn/autocomplete.js@npm:0.38.1"
+  dependencies:
+    cssesc: ^3.0.0
+    immediate: ^3.2.3
+  checksum: d88b61f12c383856b8d5cedf176a6d07a21e013dc2c78be029af81e2e026ece2bb988c6ea7f9951a2759c2e6f806ea1d1c9627bf36d9cbe376e897a94ce5da09
+  languageName: node
+  linkType: hard
+
+"@easyops-cn/docusaurus-search-local@npm:^0.35.0":
+  version: 0.35.0
+  resolution: "@easyops-cn/docusaurus-search-local@npm:0.35.0"
+  dependencies:
+    "@docusaurus/plugin-content-docs": ^2.0.0-rc.1
+    "@docusaurus/theme-translations": ^2.0.0-rc.1
+    "@docusaurus/utils": ^2.0.0-rc.1
+    "@docusaurus/utils-common": ^2.0.0-rc.1
+    "@docusaurus/utils-validation": ^2.0.0-rc.1
+    "@easyops-cn/autocomplete.js": ^0.38.1
+    "@node-rs/jieba": ^1.6.0
+    cheerio: ^1.0.0-rc.3
+    clsx: ^1.1.1
+    debug: ^4.2.0
+    fs-extra: ^10.0.0
+    klaw-sync: ^6.0.0
+    lunr: ^2.3.9
+    lunr-languages: ^1.4.0
+    mark.js: ^8.11.1
+    tslib: ^2.4.0
+  peerDependencies:
+    "@docusaurus/theme-common": ^2.0.0-rc.1
+    react: ^16.14.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
+  checksum: 726b7b5d52f3fd01286e5a97bb2f5d27ae0ace2be7a7742c92b0bf11d56f2f44a16f6b7af556f5676ffa2a3b94c244d17ea9804894553f94ba66b98249e1e10f
   languageName: node
   linkType: hard
 
@@ -2412,6 +2450,145 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: cb25b5ce153608c2a4291390456488e100c5e3ac48a913875c98182836e2a9f315d4f96e85cf6f7d4b1eadff8d08d13356e38891b472894155bcb2c4aeaf3b1c
+  languageName: node
+  linkType: hard
+
+"@node-rs/jieba-android-arm-eabi@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@node-rs/jieba-android-arm-eabi@npm:1.6.2"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@node-rs/jieba-android-arm64@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@node-rs/jieba-android-arm64@npm:1.6.2"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@node-rs/jieba-darwin-arm64@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@node-rs/jieba-darwin-arm64@npm:1.6.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@node-rs/jieba-darwin-x64@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@node-rs/jieba-darwin-x64@npm:1.6.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@node-rs/jieba-freebsd-x64@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@node-rs/jieba-freebsd-x64@npm:1.6.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@node-rs/jieba-linux-arm-gnueabihf@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@node-rs/jieba-linux-arm-gnueabihf@npm:1.6.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@node-rs/jieba-linux-arm64-gnu@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@node-rs/jieba-linux-arm64-gnu@npm:1.6.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@node-rs/jieba-linux-arm64-musl@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@node-rs/jieba-linux-arm64-musl@npm:1.6.2"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@node-rs/jieba-linux-x64-gnu@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@node-rs/jieba-linux-x64-gnu@npm:1.6.2"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@node-rs/jieba-linux-x64-musl@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@node-rs/jieba-linux-x64-musl@npm:1.6.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@node-rs/jieba-win32-arm64-msvc@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@node-rs/jieba-win32-arm64-msvc@npm:1.6.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@node-rs/jieba-win32-ia32-msvc@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@node-rs/jieba-win32-ia32-msvc@npm:1.6.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@node-rs/jieba-win32-x64-msvc@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@node-rs/jieba-win32-x64-msvc@npm:1.6.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@node-rs/jieba@npm:^1.6.0":
+  version: 1.6.2
+  resolution: "@node-rs/jieba@npm:1.6.2"
+  dependencies:
+    "@node-rs/jieba-android-arm-eabi": 1.6.2
+    "@node-rs/jieba-android-arm64": 1.6.2
+    "@node-rs/jieba-darwin-arm64": 1.6.2
+    "@node-rs/jieba-darwin-x64": 1.6.2
+    "@node-rs/jieba-freebsd-x64": 1.6.2
+    "@node-rs/jieba-linux-arm-gnueabihf": 1.6.2
+    "@node-rs/jieba-linux-arm64-gnu": 1.6.2
+    "@node-rs/jieba-linux-arm64-musl": 1.6.2
+    "@node-rs/jieba-linux-x64-gnu": 1.6.2
+    "@node-rs/jieba-linux-x64-musl": 1.6.2
+    "@node-rs/jieba-win32-arm64-msvc": 1.6.2
+    "@node-rs/jieba-win32-ia32-msvc": 1.6.2
+    "@node-rs/jieba-win32-x64-msvc": 1.6.2
+  dependenciesMeta:
+    "@node-rs/jieba-android-arm-eabi":
+      optional: true
+    "@node-rs/jieba-android-arm64":
+      optional: true
+    "@node-rs/jieba-darwin-arm64":
+      optional: true
+    "@node-rs/jieba-darwin-x64":
+      optional: true
+    "@node-rs/jieba-freebsd-x64":
+      optional: true
+    "@node-rs/jieba-linux-arm-gnueabihf":
+      optional: true
+    "@node-rs/jieba-linux-arm64-gnu":
+      optional: true
+    "@node-rs/jieba-linux-arm64-musl":
+      optional: true
+    "@node-rs/jieba-linux-x64-gnu":
+      optional: true
+    "@node-rs/jieba-linux-x64-musl":
+      optional: true
+    "@node-rs/jieba-win32-arm64-msvc":
+      optional: true
+    "@node-rs/jieba-win32-ia32-msvc":
+      optional: true
+    "@node-rs/jieba-win32-x64-msvc":
+      optional: true
+  checksum: 3d5264170db8909c64c4c2dc6bc5a6a47198a09fa7242143ae5e5a413b8ec604a607f2db8458f580824316b1fd48c1f06e00c7688e6964285db82667f96e5508
   languageName: node
   linkType: hard
 
@@ -4125,7 +4302,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cheerio@npm:^1.0.0-rc.12":
+"cheerio@npm:^1.0.0-rc.12, cheerio@npm:^1.0.0-rc.3":
   version: 1.0.0-rc.12
   resolution: "cheerio@npm:1.0.0-rc.12"
   dependencies:
@@ -5239,7 +5416,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.3, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.2.0, debug@npm:^4.3.3, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -6337,7 +6514,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^10.1.0":
+"fs-extra@npm:^10.0.0, fs-extra@npm:^10.1.0":
   version: 10.1.0
   resolution: "fs-extra@npm:10.1.0"
   dependencies:
@@ -6644,7 +6821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: ac85f94da92d8eb6b7f5a8b20ce65e43d66761c55ce85ac96df6865308390da45a8d3f0296dd3a663de65d30ba497bd46c696cc1e248c72b13d6d567138a4fc7
@@ -7179,6 +7356,13 @@ __metadata:
   bin:
     image-size: bin/image-size.js
   checksum: 01745fdb47f87cecf538e69c63f9adc5bfab30a345345c2de91105f3afbd1bfcfba1256af02bf3323077b33b0004469a837e077bf0cbb9c907e9c1e9e7547585
+  languageName: node
+  linkType: hard
+
+"immediate@npm:^3.2.3":
+  version: 3.3.0
+  resolution: "immediate@npm:3.3.0"
+  checksum: 634b4305101e2452eba6c07d485bf3e415995e533c94b9c3ffbc37026fa1be34def6e4f2276b0dc2162a3f91628564a4bfb26280278b89d3ee54624e854d2f5f
   languageName: node
   linkType: hard
 
@@ -7826,6 +8010,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"klaw-sync@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "klaw-sync@npm:6.0.0"
+  dependencies:
+    graceful-fs: ^4.1.11
+  checksum: 0da397f8961313c3ef8f79fb63af9002cde5a8fb2aeb1a37351feff0dd6006129c790400c3f5c3b4e757bedcabb13d21ec0a5eaef5a593d59515d4f2c291e475
+  languageName: node
+  linkType: hard
+
 "kleur@npm:^3.0.3":
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
@@ -8104,6 +8297,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lunr-languages@npm:^1.4.0":
+  version: 1.10.0
+  resolution: "lunr-languages@npm:1.10.0"
+  checksum: e8fd7562f5e12d9071242bd9fe12795518119eaddc771f0f9bce992dff3ada2eb09771c348b1dbfec1ea3405ebd435cbaae4681347b3297db1c41e2a6f29a634
+  languageName: node
+  linkType: hard
+
+"lunr@npm:^2.3.9":
+  version: 2.3.9
+  resolution: "lunr@npm:2.3.9"
+  checksum: 176719e24fcce7d3cf1baccce9dd5633cd8bdc1f41ebe6a180112e5ee99d80373fe2454f5d4624d437e5a8319698ca6837b9950566e15d2cae5f2a543a3db4b8
+  languageName: node
+  linkType: hard
+
 "make-dir@npm:^3.0.0, make-dir@npm:^3.0.2, make-dir@npm:^3.1.0":
   version: 3.1.0
   resolution: "make-dir@npm:3.1.0"
@@ -8134,6 +8341,13 @@ __metadata:
     socks-proxy-agent: ^7.0.0
     ssri: ^9.0.0
   checksum: 2332eb9a8ec96f1ffeeea56ccefabcb4193693597b132cd110734d50f2928842e22b84cfa1508e921b8385cdfd06dda9ad68645fed62b50fff629a580f5fb72c
+  languageName: node
+  linkType: hard
+
+"mark.js@npm:^8.11.1":
+  version: 8.11.1
+  resolution: "mark.js@npm:8.11.1"
+  checksum: aa6b9ae1c67245348d5b7abd253ef2acd6bb05c6be358d7d192416d964e42665fc10e0e865591c6f93ab9b57e8da1f23c23216e8ebddb580905ea7a0c0df15d4
   languageName: node
   linkType: hard
 
@@ -8172,6 +8386,7 @@ __metadata:
     "@docusaurus/theme-classic": ^2.4.0
     "@docusaurus/theme-common": ^2.4.0
     "@docusaurus/theme-mermaid": ^2.4.0
+    "@easyops-cn/docusaurus-search-local": ^0.35.0
     "@mdx-js/react": ^1.6.22
     "@tsconfig/docusaurus": ^1.0.6
     autoprefixer: ^10.4.13


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/119703292/232556838-657ab686-a66f-4eda-a8e0-24c345695737.png)

This PR adds a plugin that uses lunr to generate an index based local search. This means the payload for loading the site is slightly larger, but no API calls will be made as a tradeoff. In order to preview this functionality, the static pages must be built via `yarn build` then run `yarn serve`