### PR TITLE
PLT-5866 - Remove unused algolia config reference

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -51,8 +51,8 @@ const config = {
       require.resolve("@easyops-cn/docusaurus-search-local"),
       /** @type {import("@easyops-cn/docusaurus-search-local").PluginOptions} */
       ({
-
         hashed: true,
+        indexBlog: false,
       }),
     ],
   ],
@@ -186,11 +186,6 @@ const config = {
           },
         ],
         // copyright: `Copyright © ${new Date().getFullYear()} My Project, Inc. Built with Docusaurus.`,
-      },
-      algolia: {
-        appId: 'MY_APP_ID',
-        apiKey: 'MY_API_KEY',
-        indexName: '_INDEX',
       },
       prism: {
         theme: lightCodeTheme,


### PR DESCRIPTION
Fixes `[WARNING] Duplicate routes found!
- Attempting to create page at /search, but a page already exists at this route.
This could lead to non-deterministic routing behavior.` and ensures the local search plugin does not attempt to index a blogDir.