### PR TITLE
Update index.tsx to fix link to Tutorials > Videos

### DIFF
--- a/src/components/TutorialSections/index.tsx
+++ b/src/components/TutorialSections/index.tsx
@@ -78,7 +78,7 @@ function TutorialSections() {
                 </p>
               </div>
               <div className="card__footer">
-                <Link to="/tutorials/concepts/overview">
+                <Link to="/tutorials/videos">
                   Start <ArrowRight className="arrow" />
                 </Link>
               </div>


### PR DESCRIPTION
When on the tutorials landing page, the link to Videos links to concepts > overview. 

Fixed link to go to tutorials > videos. 