### PR TITLE
Update developer-tools playground.md

### DIFF
--- a/docs/developer-tools/playground.md
+++ b/docs/developer-tools/playground.md
@@ -50,6 +50,6 @@ Experienced Haskell developers can use the embedded Haskell editor in the Playgr
 
 ### IOG Academy's self-paced course on learning Haskell
 
-* **[On YouTube](https://youtu.be/pkU8eiNZipQ)**
+* **[On YouTube](https://www.youtube.com/playlist?list=PLNEK_Ejlx3x1D9Vq5kqeC3ZDEP7in4dqb)**
 
 * **[On GitHub](https://github.com/input-output-hk/haskell-course)**


### PR DESCRIPTION
At the bottom of the page, replaced youtube link for first video of the Haskell course to instead point to a link for the entire playlist of the Haskell course.