### PR TITLE
PLT-6151 - feat: add Matomo

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -145,7 +145,11 @@ const config = {
       },
     }
   ),
-  scripts
+  scripts,
+  customFields: {
+    matomoBaseUrl: process.env.MATOMO_BASE_URL,
+    matomoSiteId: process.env.MATOMO_SITE_ID
+  }
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@datapunt/matomo-tracker-react": "^0.5.1",
     "@docusaurus/core": "^2.4.1",
     "@docusaurus/plugin-content-docs": "^2.4.1",
     "@docusaurus/plugin-content-pages": "^2.4.1",

--- a/src/context/MatomoContext.tsx
+++ b/src/context/MatomoContext.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import { createInstance, MatomoProvider } from "@datapunt/matomo-tracker-react";
+import { useLocation } from "@docusaurus/router";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+
+export const MatomoContext: React.FC<{ children: React.ReactNode; }> = ({ children }) => {
+  const { siteConfig } = useDocusaurusContext();
+  const location = useLocation();
+  const href = useRef(undefined);
+
+  const matomo: ReturnType<typeof createInstance> | undefined = useMemo(() => {
+    const urlBase = siteConfig.customFields.matomoBaseUrl;
+    const siteId = siteConfig.customFields.matomoSiteId;
+    if (typeof urlBase === "string" && typeof siteId === "string") {
+      return createInstance({
+        urlBase,
+        siteId: parseInt(siteId, 10)
+      });
+    }
+  }, [siteConfig]);
+
+  useEffect(() => {
+    const url = new URL(location.pathname, window.location.origin);
+    url.search = location.search;
+    if (url.href !== href.current) {
+      // We want to send the current document's title to matomo instead of the
+      // old one's, so we use `setTimeout` to defer execution to the next tick.
+      // See https://github.com/facebook/docusaurus/pull/7424
+      setTimeout(() => {
+        matomo?.trackPageView({ href: url.href });
+      }, 0);
+    }
+    href.current = url.href;
+  }, [location, matomo]);
+
+  return <MatomoProvider value={matomo}>{children}</MatomoProvider>;
+};

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { MatomoContext } from "@site/src/context/MatomoContext";
+
+export default function Root({ children }) {
+  return (
+    <MatomoContext>
+      {children}
+    </MatomoContext>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1656,6 +1656,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@datapunt/matomo-tracker-js@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "@datapunt/matomo-tracker-js@npm:0.5.1"
+  checksum: b6ed7f9120c896a93c342a3e8c53eec7cd5fcf85106f2b206fff33aa3144a9b008de79d922024db8b376be0c135e06e51b7da0699dbdd37f53c1cff27eb85cd3
+  languageName: node
+  linkType: hard
+
+"@datapunt/matomo-tracker-react@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "@datapunt/matomo-tracker-react@npm:0.5.1"
+  dependencies:
+    "@datapunt/matomo-tracker-js": ^0.5.1
+  peerDependencies:
+    react: ">= 16.8.0"
+  checksum: 3284634192917862229fac62c32900464bb85c1bdbf67953680cc267ac9abc4301259b1c6b6c56f734904b5f1753532f6898719eb92af49d32ed5d1a54a64512
+  languageName: node
+  linkType: hard
+
 "@discoveryjs/json-ext@npm:0.5.7":
   version: 0.5.7
   resolution: "@discoveryjs/json-ext@npm:0.5.7"
@@ -8392,6 +8410,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "marlowe-doc@workspace:."
   dependencies:
+    "@datapunt/matomo-tracker-react": ^0.5.1
     "@docusaurus/core": ^2.4.1
     "@docusaurus/module-type-aliases": ^2.4.1
     "@docusaurus/plugin-content-docs": ^2.4.1


### PR DESCRIPTION
https://matomo.cw.iog.io/index.php?module=CoreHome&action=index&date=today&period=day&idSite=49&updated=1#?period=day&date=today&category=Dashboard_Dashboard&subcategory=1

https://docusaurus.io/docs/swizzling#wrapper-your-site-with-root
> The <Root> component is rendered at the very top of the React tree, above the theme <Layout>, and never unmounts. It is the perfect place to add stateful logic that should not be re-initialized across navigations (user authentication status, shopping cart state...). Use this component to render React Context providers.


Todo
- [x] Add Matomo config for the Prod Marlowe Docs site
- [x] Add `MATOMO_SITE_ID` to Vercel for Prod deploys