### PR TITLE
Add link to Deploying Marlowe Runtime tutorial from main Runtime docs page

### DIFF
--- a/docs/developer-tools/runtime/marlowe-runtime.md
+++ b/docs/developer-tools/runtime/marlowe-runtime.md
@@ -40,9 +40,11 @@ The ReadMe file covers the following topics:
 
 See also: 
 
-## [Runtime protocol reference](runtime-protocol-reference/runtime-protocol-reference.md)
+### [Deploying Marlowe Runtime](../../../tutorials/playbooks/deploy-marlowe-runtime)
 
-## Runtime video tutorials
+### [Runtime protocol reference](runtime-protocol-reference/runtime-protocol-reference.md)
+
+### Runtime video tutorials
 
 | Video title | Presenter | Date |
 |-------------|-----------|-------------|

--- a/tutorials/playbooks/deploy-marlowe-runtime.mdx
+++ b/tutorials/playbooks/deploy-marlowe-runtime.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploy Marlowe Runtime
+title: Deploying Marlowe Runtime
 ---
 
 In this tutorial, you will deploy Marlowe Runtime with Docker in a Nix environment.


### PR DESCRIPTION
Added a cross-reference link to the tutorial on Deploying Marlowe Runtime from the bottom of the main Marlowe Runtime docs page. 
