### PR TITLE
Adding the word *smart* for clarification to the Introduction.mdx

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -19,12 +19,12 @@ import Tool from '@site/static/icons/tools.svg';
 <div className="gallery">
   <div className="sub-heading">
     <div className="front-matter">
-      <p>Marlowe is an ecosystem of tools and languages to enable development of financial and transactional contracts. Formal proofs, extensive testing, and analysis tools provide strong assurances for the safety of Marlowe contracts. <br />
+      <p>Marlowe is an ecosystem of tools and languages to enable development of financial and transactional smart contracts. Formal proofs, extensive testing, and analysis tools provide strong assurances for the safety of Marlowe smart contracts. <br />
       <br />
       Marlowe includes a full suite of tooling to support all skill levels, for both the community and enterprises.
       <br />
       <br />
-      A Marlowe contract is built by combining a small number of building blocks that describe making a payment, making an observation of something in the "real world," waiting until a certain condition becomes true, and other similar types of concepts.
+      A Marlowe smart contract is built by combining a small number of building blocks that describe making a payment, making an observation of something in the "real world," waiting until a certain condition becomes true, and other similar types of concepts.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Received feedback that it was causing a little bit of confusion that the word *smart* was not present in the introduction when talking about Marlowe contracts.