### PR TITLE
Manual fix to add operationID, description, and summary to /healthcheck

### DIFF
--- a/static/api/openapi.latest.json
+++ b/static/api/openapi.latest.json
@@ -1966,7 +1966,7 @@
     },
     "/healthcheck": {
       "get": {
-        "operationId": "health-check-endpoint",
+        "operationId": "healthcheck",
         "description": "Returns the health status of the runtime service.",
         "responses": {
           "200": {
@@ -2076,7 +2076,7 @@
           }
         },
         "security": [],
-        "summary": "Get health of runtime"
+        "summary": "Check if the server is running and ready to respond to requests."
       }
     },
     "/payouts": {


### PR DESCRIPTION
Manual patch to avoid needing to cut a release since the schema is generated from code.