### PR TITLE
added Marlowe starter kit videos to Tutorials > Videos

### DIFF
--- a/tutorials/videos.mdx
+++ b/tutorials/videos.mdx
@@ -13,6 +13,20 @@ The videos listed below cover the full spectrum of topics related to Marlowe. So
 | [Marlowe on Cardano Explained](https://youtu.be/vv2rJLN2Y1c) | Input Output | May 2021 | 
 
 
+## Marlowe starter kit videos
+
+| Video Title | Presenter | Date |
+|-------------|-----------|-------------|
+| [Using Marlowe Runtime's CLI](https://www.youtube.com/watch?v=pjDtuD5rimI) | Brian Bush | Apr 2023 | 
+| [Using Marlowe Runtime's REST API](https://www.youtube.com/watch?v=wgJVdkM2pBY) | Brian Bush | Apr 2023 | 
+| [Zero-coupon bond using Marlowe's CLI](https://www.youtube.com/watch?v=ELc72BKf7ec) | Brian Bush | Apr 2023 | 
+| [Escrow using Marlowe Runtime's REST API](https://www.youtube.com/watch?v=E8m-PKbS9TI) | Brian Bush | Apr 2023 | 
+| [Swap of ada for Djed using Marlowe Runtime's REST API](https://www.youtube.com/watch?v=sSrVCRNoytU) | Brian Bush | Apr 2023 | 
+| [Simple web application using a CIP-30 wallet](https://www.youtube.com/watch?v=EsILiHiNZWk) | Brian Bush | May 2023 | 
+| [Experimental web application using a CIP-45 wallet](https://www.youtube.com/watch?v=3cR8tq0WE_8) | Brian Bush | Sep 2023 | 
+| [Minting with Marlowe tools](https://www.youtube.com/watch?v=S0MOipqXpmQ) | Brian Bush | Oct 2023 | 
+
+
 ## [Marlowe Pioneers 1st Cohort](https://www.youtube.com/channel/UCX9j__vYOJu00iqBrCzecVw/playlists?view=50&shelf_id=2)
 
 | Video Title | Presenter | Date |


### PR DESCRIPTION
As a cross-reference, added the Marlowe starter kit videos to the Tutorials > Videos page. These videos will be migrating to the IOG Academy rather than living on Brian's personal youtube channel. So we will need to update the links once that change has happened. 