### PR TITLE
adding ts-sdk videos to tutorials-videos index page

### DIFF
--- a/tutorials/videos.mdx
+++ b/tutorials/videos.mdx
@@ -13,6 +13,15 @@ The videos listed below cover the full spectrum of topics related to Marlowe. So
 | [Marlowe on Cardano Explained](https://youtu.be/vv2rJLN2Y1c) | Input Output | May 2021 | 
 
 
+## Marlowe TypeScript SDK videos
+
+| Video Title | Presenter | Date |
+|-------------|-----------|-------------|
+| [Marlowe TypeScript SDK demo (beta)](https://youtu.be/0Qa1CsZUGnw?si=lEsmSm-8vUba5UgJ) | Nick Stanford | Dec 2023 | 
+| [Marlowe Playground and TypeScript SDK](https://youtu.be/dsF-eADnOXE?si=wmGh4BUQy_wczjjK) | Nick Stanford | Jan 2024 | 
+| [Marlowe TypeScript SDK: deploying and interacting with contracts](https://youtu.be/7XsuT8D8L4Q?si=Z_XuamcZeZEjr_48) | Nick Stanford | Jan 2024 | 
+| [Marlowe TypeScript SDK: Smart gift card example](https://youtu.be/bTpMZLmZU5k?si=JnILI80yonHE0rGy) | Nick Stanford | Jan 2024 | 
+
 ## Marlowe starter kit videos
 
 | Video Title | Presenter | Date |


### PR DESCRIPTION
This PR adds links and titles of the four TS-SDK videos to the Tutorials > Videos index page. 